### PR TITLE
Initial Phoenix and Mongo skeleton

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,8 @@
+[
+  inputs: [
+    "mix.exs",
+    "config/*.exs",
+    "lib/**/*.{ex,exs}",
+    "test/**/*.{ex,exs}"
+  ]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/_build
+/deps
+.DS_Store
+*.ez

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM elixir:1.15-alpine AS build
+WORKDIR /app
+ENV MIX_ENV=prod
+COPY mix.exs mix.lock* ./
+COPY config config
+RUN mix deps.get --only prod
+COPY . .
+RUN mix deps.compile && mix compile
+
+FROM elixir:1.15-alpine
+WORKDIR /app
+ENV MIX_ENV=prod
+COPY --from=build /app .
+CMD ["elixir", "--erl", "+K true", "-S", "mix", "phx.server"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# elixir-with-mongodb
-template project with elixir and mongodb and infra on docker
+# PhxMongo Example
+
+Simple Phoenix + MongoDB project with Docker.
+
+## Setup
+
+```bash
+# build and start
+docker-compose up --build
+```
+
+App will be available on http://localhost:4000
+
+## Example API calls
+
+Create user:
+```bash
+curl -X POST http://localhost:4000/api/users \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Bob","email":"bob@example.com","password":"secret"}'
+```
+
+Login:
+```bash
+curl -X POST http://localhost:4000/api/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"bob@example.com","password":"secret"}'
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,9 @@
+import Config
+
+config :phx_mongo, PhxMongoWeb.Endpoint,
+  url: [host: System.get_env("PHX_HOST", "localhost"), port: 80],
+  render_errors: [view: PhxMongoWeb.ErrorView, accepts: ~w(json), layout: false],
+  pubsub_server: PhxMongo.PubSub,
+  live_view: [signing_salt: "SALTSALT"]
+
+config :phoenix, :json_library, Jason

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,8 @@
+import Config
+
+config :phx_mongo, PhxMongoWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4000],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: String.duplicate("0", 64)

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :phx_mongo, PhxMongoWeb.Endpoint,
+  url: [host: System.get_env("PHX_HOST", "example.com"), port: 80],
+  cache_static_manifest: "priv/static/cache_manifest.json"
+
+config :logger, level: :info

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,13 @@
+import Config
+
+if config_env() == :prod do
+  config :phx_mongo, PhxMongoWeb.Endpoint,
+    http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+    secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+
+  config :phx_mongo, PhxMongo.Mongo,
+    url: System.get_env("MONGODB_URL") || "mongodb://mongo:27017/phx_mongo"
+else
+  config :phx_mongo, PhxMongo.Mongo,
+    url: System.get_env("MONGODB_URL") || "mongodb://mongo:27017/phx_mongo"
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :phx_mongo, PhxMongoWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4002],
+  secret_key_base: String.duplicate("0", 64)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    environment:
+      - MONGODB_URL=mongodb://mongo:27017/phx_mongo
+      - SECRET_KEY_BASE=supersecretkeybase12345678901234567890123456789012345678
+    ports:
+      - "4000:4000"
+    depends_on:
+      mongo:
+        condition: service_healthy
+  mongo:
+    image: mongo:6
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mongo", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      retries: 5

--- a/lib/phx_mongo.ex
+++ b/lib/phx_mongo.ex
@@ -1,0 +1,5 @@
+defmodule PhxMongo do
+  @moduledoc """
+  Entry point for the application contexts.
+  """
+end

--- a/lib/phx_mongo/accounts/accounts.ex
+++ b/lib/phx_mongo/accounts/accounts.ex
@@ -1,0 +1,76 @@
+defmodule PhxMongo.Accounts do
+  alias PhxMongo.Accounts.User
+
+  @coll "users"
+
+  def list_users do
+    Mongo.find(:mongo, @coll, %{})
+    |> Enum.map(&bson_to_user/1)
+  end
+
+  def get_user(id) do
+    case Mongo.find_one(:mongo, @coll, %{_id: to_object_id(id)}) do
+      nil -> nil
+      doc -> bson_to_user(doc)
+    end
+  end
+
+  def create_user(attrs) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    user = %{
+      name: attrs["name"],
+      email: attrs["email"],
+      password_hash: Bcrypt.hash_pwd_salt(attrs["password"]),
+      inserted_at: now,
+      updated_at: now
+    }
+
+    {:ok, %{"inserted_id" => id}} = Mongo.insert_one(:mongo, @coll, user)
+    get_user(id)
+  end
+
+  def update_user(id, attrs) do
+    updates =
+      Enum.into(attrs, %{}, fn {k, v} -> {String.to_atom(k), v} end)
+      |> Map.put(:updated_at, DateTime.utc_now() |> DateTime.truncate(:second))
+
+    Mongo.update_one(:mongo, @coll, %{_id: to_object_id(id)}, %{"$set" => updates})
+    get_user(id)
+  end
+
+  def delete_user(id) do
+    Mongo.delete_one(:mongo, @coll, %{_id: to_object_id(id)})
+    :ok
+  end
+
+  def authenticate(email, password) do
+    case Mongo.find_one(:mongo, @coll, %{email: email}) do
+      nil ->
+        :error
+
+      doc ->
+        user = bson_to_user(doc)
+
+        if Bcrypt.verify_pass(password, user.password_hash) do
+          {:ok, user}
+        else
+          :error
+        end
+    end
+  end
+
+  defp bson_to_user(doc) do
+    %User{
+      id: doc["_id"] |> BSON.ObjectId.encode!(),
+      name: doc["name"],
+      email: doc["email"],
+      password_hash: doc["password_hash"],
+      inserted_at: doc["inserted_at"],
+      updated_at: doc["updated_at"]
+    }
+  end
+
+  defp to_object_id(id) when is_binary(id), do: BSON.ObjectId.decode!(id)
+  defp to_object_id(%BSON.ObjectId{} = id), do: id
+end

--- a/lib/phx_mongo/accounts/user.ex
+++ b/lib/phx_mongo/accounts/user.ex
@@ -1,0 +1,4 @@
+defmodule PhxMongo.Accounts.User do
+  @derive {Jason.Encoder, only: [:id, :name, :email, :inserted_at, :updated_at]}
+  defstruct [:id, :name, :email, :password_hash, :inserted_at, :updated_at]
+end

--- a/lib/phx_mongo/application.ex
+++ b/lib/phx_mongo/application.ex
@@ -1,0 +1,19 @@
+defmodule PhxMongo.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      {Phoenix.PubSub, name: PhxMongo.PubSub},
+      PhxMongo.Mongo,
+      PhxMongoWeb.Endpoint
+    ]
+
+    opts = [strategy: :one_for_one, name: PhxMongo.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def config_change(changed, _new, removed) do
+    PhxMongoWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/lib/phx_mongo/mongo.ex
+++ b/lib/phx_mongo/mongo.ex
@@ -1,0 +1,13 @@
+defmodule PhxMongo.Mongo do
+  use GenServer
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    url = Application.fetch_env!(:phx_mongo, __MODULE__)[:url]
+    {:ok, conn} = Mongo.start_link(url: url, name: :mongo)
+    {:ok, conn}
+  end
+end

--- a/lib/phx_mongo_web.ex
+++ b/lib/phx_mongo_web.ex
@@ -1,0 +1,26 @@
+defmodule PhxMongoWeb do
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: PhxMongoWeb
+      import Plug.Conn
+      alias PhxMongoWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def view do
+    quote do
+      use Phoenix.View, root: "lib/phx_mongo_web/templates", namespace: PhxMongoWeb
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+      import Plug.Conn
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/lib/phx_mongo_web/controllers/session_controller.ex
+++ b/lib/phx_mongo_web/controllers/session_controller.ex
@@ -1,0 +1,19 @@
+defmodule PhxMongoWeb.SessionController do
+  use PhxMongoWeb, :controller
+  alias PhxMongo.Accounts
+
+  def create(conn, %{"email" => email, "password" => pass}) do
+    case Accounts.authenticate(email, pass) do
+      {:ok, user} ->
+        token = Phoenix.Token.sign(PhxMongoWeb.Endpoint, "user", user.id)
+        json(conn, %{token: token, user: user})
+
+      :error ->
+        send_resp(conn, 401, "unauthorized")
+    end
+  end
+
+  def delete(conn, _params) do
+    send_resp(conn, 204, "")
+  end
+end

--- a/lib/phx_mongo_web/controllers/user_controller.ex
+++ b/lib/phx_mongo_web/controllers/user_controller.ex
@@ -1,0 +1,33 @@
+defmodule PhxMongoWeb.UserController do
+  use PhxMongoWeb, :controller
+  alias PhxMongo.Accounts
+
+  def index(conn, _params) do
+    users = Accounts.list_users()
+    json(conn, users)
+  end
+
+  def create(conn, params) do
+    case Accounts.create_user(params) do
+      {:error, _} -> send_resp(conn, 400, "invalid")
+      user -> conn |> put_status(:created) |> json(user)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    case Accounts.get_user(id) do
+      nil -> send_resp(conn, 404, "not found")
+      user -> json(conn, user)
+    end
+  end
+
+  def update(conn, %{"id" => id} = params) do
+    user = Accounts.update_user(id, Map.delete(params, "id"))
+    json(conn, user)
+  end
+
+  def delete(conn, %{"id" => id}) do
+    Accounts.delete_user(id)
+    send_resp(conn, 204, "")
+  end
+end

--- a/lib/phx_mongo_web/endpoint.ex
+++ b/lib/phx_mongo_web/endpoint.ex
@@ -1,0 +1,25 @@
+defmodule PhxMongoWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :phx_mongo
+
+  socket("/socket", Phoenix.Socket)
+
+  plug(Plug.RequestId)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+
+  plug(Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Jason
+  )
+
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+
+  plug(Plug.Session,
+    store: :cookie,
+    key: "_phx_mongo_key",
+    signing_salt: "signsalt"
+  )
+
+  plug(PhxMongoWeb.Router)
+end

--- a/lib/phx_mongo_web/router.ex
+++ b/lib/phx_mongo_web/router.ex
@@ -1,0 +1,16 @@
+defmodule PhxMongoWeb.Router do
+  use Phoenix.Router
+
+  pipeline :api do
+    plug(:accepts, ["json"])
+  end
+
+  scope "/api", PhxMongoWeb do
+    pipe_through(:api)
+
+    post("/login", SessionController, :create)
+    delete("/logout", SessionController, :delete)
+
+    resources("/users", UserController, except: [:new, :edit])
+  end
+end

--- a/lib/phx_mongo_web/views/error_view.ex
+++ b/lib/phx_mongo_web/views/error_view.ex
@@ -1,0 +1,7 @@
+defmodule PhxMongoWeb.ErrorView do
+  use PhxMongoWeb, :view
+
+  def render("404.json", _assigns), do: %{error: "Not found"}
+  def render("500.json", _assigns), do: %{error: "Internal server error"}
+  def template_not_found(_, assigns), do: render("500.json", assigns)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,35 @@
+defmodule PhxMongo.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :phx_mongo,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  def application do
+    [
+      mod: {PhxMongo.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:plug_cowboy, "~> 2.6"},
+      {:jason, "~> 1.4"},
+      {:mongodb_driver, "~> 0.9"},
+      {:bcrypt_elixir, "~> 3.0"}
+    ]
+  end
+end

--- a/test/phx_mongo_test.exs
+++ b/test/phx_mongo_test.exs
@@ -1,0 +1,7 @@
+defmodule PhxMongoTest do
+  use ExUnit.Case
+
+  test "truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add mix project with Phoenix and MongoDB dependencies
- implement simple Accounts context and web controllers
- add Dockerfile and docker-compose setup for app and Mongo
- document basic usage with sample curl calls

## Testing
- `mix format`
- `mix test` *(fails: dependencies could not be fetched)*

------
https://chatgpt.com/codex/tasks/task_e_688a29f70fd0832899a3fe437bed9287